### PR TITLE
chore: Patch for MSVC

### DIFF
--- a/src/compiler.h
+++ b/src/compiler.h
@@ -1,3 +1,7 @@
 #pragma once
 
+#if defined(_MSC_VER)
+#define GXHASH_ALWAYS_INLINE static inline __forceinline
+#else
 #define GXHASH_ALWAYS_INLINE static inline __attribute__((always_inline))
+#endif

--- a/src/gxhash.h
+++ b/src/gxhash.h
@@ -17,7 +17,7 @@ static constexpr uint32_t KEYS[12] = {
 
 } // namespace gxhash
 
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(_M_X64)
 #include "platform/x86.h"
 #elif __aarch64__
 #include "platform/arm.h"
@@ -159,10 +159,12 @@ GXHASH_ALWAYS_INLINE uint64_t gxhash64(const uint8_t *in, size_t len,
   return *(reinterpret_cast<uint64_t *>(&hash));
 }
 
+#if !defined(_MSC_VER)
 GXHASH_ALWAYS_INLINE __int128 gxhash128(const uint8_t *in, size_t len,
                                         uint64_t seed) {
   impl::state hash = impl::gxhash(in, len, impl::create_seed(seed));
   return *(reinterpret_cast<__int128 *>(&hash));
 }
+#endif
 
 } // namespace gxhash

--- a/src/platform/x86.h
+++ b/src/platform/x86.h
@@ -5,7 +5,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#else
 #include <x86intrin.h>
+#endif
 
 namespace gxhash {
 
@@ -158,10 +162,12 @@ GXHASH_ALWAYS_INLINE state load_u32(uint32_t x) { return _mm_set1_epi32(x); }
 
 GXHASH_ALWAYS_INLINE state load_u64(uint64_t x) { return _mm_set1_epi64x(x); }
 
+#if !defined(_MSC_VER)
 GXHASH_ALWAYS_INLINE state load_u128(__uint128_t x) {
   auto ptr = (const __m128i *)&x;
   return _mm_loadu_si128(ptr);
 }
+#endif
 
 GXHASH_ALWAYS_INLINE state load_i8(int8_t x) { return _mm_set1_epi8(x); }
 
@@ -171,10 +177,12 @@ GXHASH_ALWAYS_INLINE state load_i32(int32_t x) { return _mm_set1_epi32(x); }
 
 GXHASH_ALWAYS_INLINE state load_i64(int64_t x) { return _mm_set1_epi64x(x); }
 
+#if !defined(_MSC_VER)
 GXHASH_ALWAYS_INLINE state load_i128(__int128_t x) {
   auto ptr = (const __m128i *)&x;
   return _mm_loadu_si128(ptr);
 }
+#endif
 
 } // namespace impl
 


### PR DESCRIPTION
Hi, thanks for the nice C++ port.

This PR adds a basic support for Microsoft Visual C++.

You can test it with the following commands in the Windows Terminal.

```pwsh
pwsh.exe

# prerequisites
vcpkg install gtest benchmark

# clone
cd "$Env:PUBLIC"
git clone https://github.com/t-mat/gxhash-cpp
cd gxhash-cpp
git checkout msvc-x64
git branch -v

# build
mkdir         msvc-build
cmake -B      msvc-build
cmake --build msvc-build --config Release --clean-first

# test
.\msvc-build\Release\gxhash-cpp-test.exe
.\msvc-build\Release\gxhash-cpp-bm.exe
```

Changes are:
- Use `_MSC_VER` to detect Microsoft Visual C++.
- Use `__forceinline`
- Use `_M_X64`
- Use `<intrin.h>`
- Abandon portable 128 bit integer functions for now.
